### PR TITLE
Fetch sound mode when polling for updates

### DIFF
--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -199,6 +199,7 @@ class BeoPlay(object):
             async with self._clientsession.get(self._host_notifications) as response:
                 data = None
                 if response.status == 200:
+                    counter = 0
                     while True:
                         data = await response.content.readline()
                         if data and len(data) > 0:
@@ -211,6 +212,8 @@ class BeoPlay(object):
                                 self._processNotification(data_json)
                                 if callback is not None:
                                     callback(data_json["notification"])
+                        if counter > 10:
+                            await self.async_get_sound_mode()
                         else:
                             break
                 else:

--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -199,7 +199,6 @@ class BeoPlay(object):
             async with self._clientsession.get(self._host_notifications) as response:
                 data = None
                 if response.status == 200:
-                    counter = 0
                     while True:
                         data = await response.content.readline()
                         if data and len(data) > 0:
@@ -212,7 +211,6 @@ class BeoPlay(object):
                                 self._processNotification(data_json)
                                 if callback is not None:
                                     callback(data_json["notification"])
-                        if counter > 10:
                             await self.async_get_sound_mode()
                         else:
                             break

--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -211,7 +211,6 @@ class BeoPlay(object):
                                 self._processNotification(data_json)
                                 if callback is not None:
                                     callback(data_json["notification"])
-                            await self.async_get_sound_mode()
                         else:
                             break
                 else:
@@ -860,6 +859,11 @@ class BeoPlay(object):
                 + data["notification"]["data"]["name"]
             )
 
+    def _processSoundMode(self, data):
+        if data["notification"]["type"] == "SOUND_ACTIVE_MODE_CHANGED":
+            self.soundMode = data["notification"]["data"]["friendlyName"]
+
+
     def _processNotification(self, data):
         """Cumulative process all the potential notification information."""
         try:
@@ -871,5 +875,7 @@ class BeoPlay(object):
             self._processState(data)
             # get currently playing music info
             self._processMusicInfo(data)
+            # get sound mode
+            self._processSoundMode(data)
         except KeyError:
             LOG.debug("Malformed notification: %s", str(data))

--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -263,10 +263,6 @@ class BeoPlay(object):
         return
     
     async def async_get_sound_mode(self):
-        # Retreive sound modes if not available
-        if not self.soundModes:
-            await self.async_get_sound_modes()
-
         # If still not available assume sound modes are not supported
         if not self.soundModes:
             return

--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -575,10 +575,6 @@ class BeoPlay(object):
                 self.on = False
 
     def getSoundMode(self):
-        # Retreive sound modes if not available
-        if not self.soundModes:
-            self.getSoundModes()
-
         # If still not available assume sound modes are not supported
         if not self.soundModes:
             return

--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -262,9 +262,18 @@ class BeoPlay(object):
         return
     
     async def async_get_sound_mode(self):
+        # Retreive sound modes if not available
+        if not self.soundModes:
+            await self.async_get_sound_modes()
+
+        # If still not available assume sound modes are not supported
+        if not self.soundModes:
+            return
+            
         r = await self.async_getReq(BEOPLAY_URL_GET_SOUND_MODE)
         if r:
-            self.soundMode = r["mode"]["active"]
+            soundModes = {v: k for k, v in self._soundModes.items()}
+            self.soundMode = soundModes[r["mode"]["active"]]
             return self.soundMode
         return
 
@@ -569,9 +578,18 @@ class BeoPlay(object):
                 self.on = False
 
     def getSoundMode(self):
+        # Retreive sound modes if not available
+        if not self.soundModes:
+            self.getSoundModes()
+
+        # If still not available assume sound modes are not supported
+        if not self.soundModes:
+            return
+            
         r = self._getReq(BEOPLAY_URL_GET_SOUND_MODE)
         if r:
-            self.soundMode = r["mode"]["active"]
+            soundModes = {v: k for k, v in self._soundModes.items()}
+            self.soundMode = soundModes[r["mode"]["active"]]
 
     def getSoundModes(self):
         r = self._getReq(BEOPLAY_URL_GET_SOUND_MODE)


### PR DESCRIPTION
This pull request includes changes to the `pybeoplay/__init__.py` file, focusing on improving the handling of sound modes and ensuring that sound modes are correctly identified and managed. The most important changes include adding a call to `async_get_sound_mode` in the `async_notificationsTask` method and modifying the `async_get_sound_mode` and `getSoundMode` methods to handle cases where sound modes are not supported.

I have tested this with a local version of the Beoplay integration and confirmed this is working. It should handle devices which do not support changing the sound modes as well.

Enhancements to sound mode handling:

* [`pybeoplay/__init__.py`](diffhunk://#diff-f8c6ffbc6f7992cd19046c23244c5d20a793e476912097c466c3b2d36a2afbc3R214): Added a call to `async_get_sound_mode` in the `async_notificationsTask` method to ensure sound mode information is updated.
* [`pybeoplay/__init__.py`](diffhunk://#diff-f8c6ffbc6f7992cd19046c23244c5d20a793e476912097c466c3b2d36a2afbc3R266-R273): Updated the `async_get_sound_mode` method to handle cases where sound modes are not supported by checking if `self.soundModes` is available.
* [`pybeoplay/__init__.py`](diffhunk://#diff-f8c6ffbc6f7992cd19046c23244c5d20a793e476912097c466c3b2d36a2afbc3R578-R585): Updated the `getSoundMode` method to handle cases where sound modes are not supported by checking if `self.soundModes` is available.