### PR TITLE
Fix sound mode attribute assignment

### DIFF
--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -902,7 +902,7 @@ class BeoPlay(object):
 
     def _processSoundMode(self, data):
         if data["notification"]["type"] == "SOUND_ACTIVE_MODE_CHANGED":
-            self.soundMode = data["notification"]["data"]["friendlyName"]
+            self._soundMode = data["notification"]["data"]["friendlyName"]
 
 
     def _processNotification(self, data):


### PR DESCRIPTION
This pull request includes a minor change to the `pybeoplay/__init__.py` file. The change updates the `def _processSoundMode(self, data):` method to use a private attribute for `soundMode`. This should fix https://github.com/giachello/beoplay/issues/43

* [`pybeoplay/__init__.py`](diffhunk://#diff-f8c6ffbc6f7992cd19046c23244c5d20a793e476912097c466c3b2d36a2afbc3L905-R905): Changed `self.soundMode` to `self._soundMode` in the `_processSoundMode` method.