### PR TITLE
Changed from info to debug

### DIFF
--- a/pybeoplay/__init__.py
+++ b/pybeoplay/__init__.py
@@ -240,7 +240,7 @@ class BeoPlay(object):
                                 data.decode("utf-8").replace("\r", "").replace("\n", "")
                             )
                             if len(data) > 0:
-                                LOG.info("Update status: %s %s", self._name, data)
+                                LOG.debug("Update status: %s %s", self._name, data)
                                 data_json = json.loads(data)
                                 self._processNotification(data_json)
                                 if callback is not None:


### PR DESCRIPTION
The info logging is not following standard logging definitions and it makes it more difficult to have relevant logging visible during local development